### PR TITLE
Fix release workflow: build zip only, no WP.org deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   release:
-    name: Deploy
+    name: Build and attach zip
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://wordpress.org/plugins/make-postmeta-faster/
+      url: https://github.com/${{ github.repository }}/releases
     steps:
       - uses: actions/checkout@v4
 
@@ -41,23 +41,20 @@ jobs:
           npm run build:css
           npm run dump
 
-      - name: Generate readme.txt
-        uses: tarosky/workflows/actions/wp-readme@main
-
       - name: Versioning
         uses: tarosky/workflows/actions/versioning@main
         with:
           version: ${{ github.event.release.tag_name }}
           files: make-postmeta-faster.php
 
-      - name: Deploy to WordPress Directory
-        uses: 10up/action-wordpress-plugin-deploy@stable
-        with:
-          generate-zip: true
-        env:
-          SLUG: make-postmeta-faster
-          SVN_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}
+      - name: Clean Package
+        uses: tarosky/workflows/actions/distignore@main
+
+      - name: Zip Archive
+        run: |
+          mkdir ${{ github.event.repository.name }}
+          rsync -av --exclude=${{ github.event.repository.name }} --exclude=.git ./ ./${{ github.event.repository.name }}/
+          zip -r ./${{ github.event.repository.name }}.zip ./${{ github.event.repository.name }}
 
       - name: Upload release asset
         run: gh release upload ${{ github.event.release.tag_name }} ${{ github.workspace }}/${{ github.event.repository.name }}.zip --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           npm run build:css
           npm run dump
 
+      - name: Generate readme.txt
+        uses: tarosky/workflows/actions/wp-readme@main
+
       - name: Versioning
         uses: tarosky/workflows/actions/versioning@main
         with:


### PR DESCRIPTION
## Summary

このプラグインはまだ WordPress.org 公式ディレクトリに公開していないため、10up/action-wordpress-plugin-deploy を削除し、GitHub Release への zip アタッチのみに変更。

## 変更内容

**削除:**
- `tarosky/workflows/actions/wp-readme@main` (WP.org用 readme.txt 生成)
- `10up/action-wordpress-plugin-deploy@stable` (WP.org SVN デプロイ)
- Environment URL の WP.org 参照

**追加:**
- `tarosky/workflows/actions/distignore@main` で .distignore に従ってファイル除去
- yahoo-delivery と同じ rsync + zip パターン
- Environment URL を GitHub Releases に変更

## フロー

1. GitHub でリリース公開 → ワークフロー発火
2. composer install --no-dev + npm ci + build
3. Versioning (main PHP ファイルのバージョン置換)
4. distignore クリーンアップ
5. rsync で一時ディレクトリにコピー → zip
6. `gh release upload` で発火元リリースに attach

## 将来 WordPress.org に公開する場合

10up アクションと readme.txt 生成ステップを戻せばOK。そのときは `WP_ORG_USERNAME` / `WP_ORG_PASSWORD` Secrets も設定する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)