### PR TITLE
Support wp_usermeta and wp_termmeta tables

### DIFF
--- a/src/Api/IndexApi.php
+++ b/src/Api/IndexApi.php
@@ -3,6 +3,9 @@
 namespace Tarosky\MakePostmetaFaster\Api;
 
 use Tarosky\MakePostmetaFaster\IndexChecker\PostMetaIndexChecker;
+use Tarosky\MakePostmetaFaster\IndexChecker\TermMetaIndexChecker;
+use Tarosky\MakePostmetaFaster\IndexChecker\UserMetaIndexChecker;
+use Tarosky\MakePostmetaFaster\Pattern\AbstractIndexChecker;
 use Tarosky\MakePostmetaFaster\Pattern\SingletonPattern;
 
 /**
@@ -12,7 +15,16 @@ class IndexApi extends SingletonPattern {
 
 	const NAMESPACE = 'mpmf/v1';
 
-	const ROUTE = '/index';
+	/**
+	 * Map of table identifier to checker class name.
+	 *
+	 * @var array<string, class-string<AbstractIndexChecker>>
+	 */
+	const TABLES = array(
+		'postmeta' => PostMetaIndexChecker::class,
+		'usermeta' => UserMetaIndexChecker::class,
+		'termmeta' => TermMetaIndexChecker::class,
+	);
 
 	/**
 	 * {@inheritDoc}
@@ -27,7 +39,18 @@ class IndexApi extends SingletonPattern {
 	 * @return void
 	 */
 	public function register_routes() {
-		register_rest_route( self::NAMESPACE, self::ROUTE, array(
+		// List all tables' status.
+		register_rest_route( self::NAMESPACE, '/index', array(
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_list' ),
+				'permission_callback' => array( $this, 'permission_check' ),
+			),
+		) );
+
+		// Per-table operations.
+		$table_pattern = '(?P<table>' . implode( '|', array_keys( self::TABLES ) ) . ')';
+		register_rest_route( self::NAMESPACE, '/index/' . $table_pattern, array(
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'handle_get' ),
@@ -70,39 +93,69 @@ class IndexApi extends SingletonPattern {
 	}
 
 	/**
-	 * Get index checker instance.
+	 * Resolve a checker instance from table identifier.
 	 *
-	 * @return PostMetaIndexChecker
+	 * @param string $table Table identifier.
+	 * @return AbstractIndexChecker|null Null if unknown.
 	 */
-	protected function checker() {
-		return PostMetaIndexChecker::get_instance();
+	protected function checker( $table ) {
+		if ( ! isset( self::TABLES[ $table ] ) ) {
+			return null;
+		}
+		$class = self::TABLES[ $table ];
+		return call_user_func( array( $class, 'get_instance' ) );
 	}
 
 	/**
-	 * Handle GET request - return index status.
+	 * Build status payload for a single table.
+	 *
+	 * @param AbstractIndexChecker $checker Checker instance.
+	 * @return array
+	 */
+	protected function build_status( AbstractIndexChecker $checker ) {
+		return array(
+			'has_index'     => $checker->has_index(),
+			'indices'       => $checker->get_indices( $checker->key_name() ),
+			'explain'       => $checker->explain(),
+			'explain_score' => $checker->explain_score(),
+			'key_length'    => $this->get_key_length( $checker ),
+		);
+	}
+
+	/**
+	 * Handle GET /index - return status for all tables.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	public function handle_list( $request ) {
+		unset( $request );
+		$result = array();
+		foreach ( array_keys( self::TABLES ) as $table ) {
+			$result[ $table ] = $this->build_status( $this->checker( $table ) );
+		}
+		return new \WP_REST_Response( $result );
+	}
+
+	/**
+	 * Handle GET /index/{table} - return status for one table.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response
 	 */
 	public function handle_get( $request ) {
-		$checker = $this->checker();
-		return new \WP_REST_Response( array(
-			'has_index'     => $checker->has_index(),
-			'indices'       => $checker->get_indices( $checker->key_name() ),
-			'explain'       => $checker->explain(),
-			'explain_score' => $checker->explain_score(),
-			'key_length'    => $this->get_key_length(),
-		) );
+		$checker = $this->checker( $request->get_param( 'table' ) );
+		return new \WP_REST_Response( $this->build_status( $checker ) );
 	}
 
 	/**
-	 * Handle POST request - add index.
+	 * Handle POST /index/{table} - add index.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function handle_post( $request ) {
-		$checker = $this->checker();
+		$checker = $this->checker( $request->get_param( 'table' ) );
 		$update  = $request->get_param( 'update' );
 		if ( $checker->has_index() ) {
 			if ( ! $update ) {
@@ -135,13 +188,13 @@ class IndexApi extends SingletonPattern {
 	}
 
 	/**
-	 * Handle DELETE request - remove index.
+	 * Handle DELETE /index/{table} - remove index.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function handle_delete( $request ) {
-		$checker = $this->checker();
+		$checker = $this->checker( $request->get_param( 'table' ) );
 		if ( ! $checker->has_index() ) {
 			return new \WP_Error(
 				'mpmf_no_index',
@@ -164,22 +217,16 @@ class IndexApi extends SingletonPattern {
 	}
 
 	/**
-	 * Get current key length settings.
+	 * Get current key length settings for the checker.
 	 *
+	 * @param AbstractIndexChecker $checker Checker instance.
 	 * @return array{meta_key: int, meta_value: int}
 	 */
-	protected function get_key_length() {
-		$length = get_option( 'mpmf-postmeta-key-length', array( 255, 64 ) );
-		if ( ! is_array( $length ) || count( $length ) !== 2 ) {
-			return array(
-				'meta_key'   => 255,
-				'meta_value' => 64,
-			);
-		}
-		list( $key_len, $val_len ) = array_map( 'intval', $length );
+	protected function get_key_length( AbstractIndexChecker $checker ) {
+		list( $key_len, $val_len ) = $checker->key_length();
 		return array(
-			'meta_key'   => min( max( 32, $key_len ), 255 ),
-			'meta_value' => max( 64, $val_len ),
+			'meta_key'   => $key_len,
+			'meta_value' => $val_len,
 		);
 	}
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -4,6 +4,8 @@ namespace Tarosky\MakePostmetaFaster;
 
 use cli\Table;
 use Tarosky\MakePostmetaFaster\IndexChecker\PostMetaIndexChecker;
+use Tarosky\MakePostmetaFaster\IndexChecker\TermMetaIndexChecker;
+use Tarosky\MakePostmetaFaster\IndexChecker\UserMetaIndexChecker;
 
 /**
  * Utility commands for Make Postmeta Faster plugin.
@@ -19,6 +21,8 @@ class Command extends \WP_CLI_Command {
 	protected function map_dbname( $name ) {
 		$map = array(
 			'postmeta' => PostMetaIndexChecker::get_instance(),
+			'usermeta' => UserMetaIndexChecker::get_instance(),
+			'termmeta' => TermMetaIndexChecker::get_instance(),
 		);
 		if ( ! isset( $map[ $name ] ) ) {
 			\WP_CLI::error( sprintf( __( '%s is not available', 'mpmf' ), $name ) );

--- a/src/IndexChecker/TermMetaIndexChecker.php
+++ b/src/IndexChecker/TermMetaIndexChecker.php
@@ -6,15 +6,15 @@ namespace Tarosky\MakePostmetaFaster\IndexChecker;
 use Tarosky\MakePostmetaFaster\Pattern\AbstractIndexChecker;
 
 /**
- * Post meta index checker.
+ * Term meta index checker.
  */
-class PostMetaIndexChecker extends AbstractIndexChecker {
+class TermMetaIndexChecker extends AbstractIndexChecker {
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function table(): string {
-		return $this->db->postmeta;
+		return $this->db->termmeta;
 	}
 
 	/**
@@ -28,11 +28,13 @@ class PostMetaIndexChecker extends AbstractIndexChecker {
 	 * {@inheritDoc}
 	 */
 	public function option_name(): string {
-		return 'mpmf-postmeta-key-length';
+		return 'mpmf-termmeta-key-length';
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Uses `order` which is a common term meta (e.g., WooCommerce category ordering) for a realistic sample.
 	 */
 	protected function explain_query(): string {
 		$query = <<<SQL
@@ -40,6 +42,6 @@ class PostMetaIndexChecker extends AbstractIndexChecker {
 			WHERE meta_key = %s
 			  AND meta_value LIKE %s
 SQL;
-		return $this->db->prepare( $query, $this->table(), '_wp_attached_file', wp_date( 'Y/m%' ) );
+		return $this->db->prepare( $query, $this->table(), 'order', '1%' );
 	}
 }

--- a/src/IndexChecker/UserMetaIndexChecker.php
+++ b/src/IndexChecker/UserMetaIndexChecker.php
@@ -6,15 +6,15 @@ namespace Tarosky\MakePostmetaFaster\IndexChecker;
 use Tarosky\MakePostmetaFaster\Pattern\AbstractIndexChecker;
 
 /**
- * Post meta index checker.
+ * User meta index checker.
  */
-class PostMetaIndexChecker extends AbstractIndexChecker {
+class UserMetaIndexChecker extends AbstractIndexChecker {
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function table(): string {
-		return $this->db->postmeta;
+		return $this->db->usermeta;
 	}
 
 	/**
@@ -28,11 +28,13 @@ class PostMetaIndexChecker extends AbstractIndexChecker {
 	 * {@inheritDoc}
 	 */
 	public function option_name(): string {
-		return 'mpmf-postmeta-key-length';
+		return 'mpmf-usermeta-key-length';
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Uses `first_name` which is a common user meta for a realistic sample.
 	 */
 	protected function explain_query(): string {
 		$query = <<<SQL
@@ -40,6 +42,6 @@ class PostMetaIndexChecker extends AbstractIndexChecker {
 			WHERE meta_key = %s
 			  AND meta_value LIKE %s
 SQL;
-		return $this->db->prepare( $query, $this->table(), '_wp_attached_file', wp_date( 'Y/m%' ) );
+		return $this->db->prepare( $query, $this->table(), 'first_name', 'A%' );
 	}
 }

--- a/src/Pattern/AbstractIndexChecker.php
+++ b/src/Pattern/AbstractIndexChecker.php
@@ -25,6 +25,58 @@ abstract class AbstractIndexChecker extends SingletonPattern {
 	abstract public function key_name(): string;
 
 	/**
+	 * Option name to store key length setting.
+	 *
+	 * @return string
+	 */
+	abstract public function option_name(): string;
+
+	/**
+	 * Explain query to check if this index is required.
+	 *
+	 * @return string
+	 */
+	abstract protected function explain_query(): string;
+
+	/**
+	 * Key length for (meta_key, meta_value) composite index.
+	 *
+	 * Reads the per-table option and sanitizes the values. Values are clamped
+	 * to MySQL / InnoDB acceptable ranges:
+	 * - meta_key: 32 - 255 (varchar(255) native size)
+	 * - meta_value: min 64 (longtext, realistic prefix length)
+	 *
+	 * @return int[] [meta_key_length, meta_value_length]
+	 */
+	public function key_length(): array {
+		$length = get_option( $this->option_name(), array( 255, 64 ) );
+		if ( ! is_array( $length ) || count( $length ) !== 2 ) {
+			return array( 255, 64 );
+		}
+		list( $key_len, $val_len ) = array_map( 'intval', $length );
+		return array(
+			min( max( 32, $key_len ), 255 ),
+			max( 64, $val_len ),
+		);
+	}
+
+	/**
+	 * A query to add index for the table.
+	 *
+	 * Common implementation for all meta tables (postmeta/usermeta/termmeta).
+	 * All three have the same meta_key/meta_value columns.
+	 *
+	 * @return string
+	 */
+	protected function add_index_query(): string {
+		$query                       = <<<SQL
+			ALTER TABLE %i ADD INDEX %i (meta_key(%d), meta_value(%d));
+SQL;
+		list( $key_len, $value_len ) = $this->key_length();
+		return $this->db->prepare( $query, $this->table(), $this->key_name(), $key_len, $value_len );
+	}
+
+	/**
 	 * Get index from key name.
 	 *
 	 * @param string $name Index name. If empty, all indices.
@@ -67,13 +119,6 @@ SQL;
 	}
 
 	/**
-	 * A query to add index for the table.
-	 *
-	 * @return string
-	 */
-	abstract protected function add_index_query(): string;
-
-	/**
 	 * Create index for table.
 	 *
 	 * @return bool
@@ -91,13 +136,6 @@ SQL;
 	public function has_index() {
 		return count( $this->get_indices( $this->key_name() ) ) > 0;
 	}
-
-	/**
-	 * Explain query to check if this index is required.
-	 *
-	 * @return string
-	 */
-	abstract protected function explain_query(): string;
 
 	/**
 	 * Explain query.

--- a/src/Setting.php
+++ b/src/Setting.php
@@ -98,5 +98,7 @@ class Setting extends SingletonPattern {
 	 */
 	public function register_settings() {
 		register_setting( 'mpmf', 'mpmf-postmeta-key-length' );
+		register_setting( 'mpmf', 'mpmf-usermeta-key-length' );
+		register_setting( 'mpmf', 'mpmf-termmeta-key-length' );
 	}
 }

--- a/src/js/admin/index.js
+++ b/src/js/admin/index.js
@@ -6,12 +6,27 @@
  */
 
 const { useState, useEffect, createRoot, render } = wp.element;
-const { Button, Card, CardBody, CardHeader, Flex, FlexItem, Notice, Spinner } =
-	wp.components;
+const {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Flex,
+	FlexItem,
+	Notice,
+	Spinner,
+	TabPanel,
+} = wp.components;
 const apiFetch = wp.apiFetch;
 const { __ } = wp.i18n;
 
-const API_PATH = 'mpmf/v1/index';
+const API_BASE = 'mpmf/v1/index';
+
+const TABLES = [
+	{ name: 'postmeta', title: __( 'Post Meta', 'mpmf' ) },
+	{ name: 'usermeta', title: __( 'User Meta', 'mpmf' ) },
+	{ name: 'termmeta', title: __( 'Term Meta', 'mpmf' ) },
+];
 
 /**
  * Index status card.
@@ -127,8 +142,9 @@ function ExplainCard( { explain, score } ) {
  * @param {Object}   props.keyLength
  * @param {Function} props.onSave
  * @param {boolean}  props.disabled
+ * @param {string}   props.table
  */
-function SettingsCard( { keyLength, onSave, disabled } ) {
+function SettingsCard( { keyLength, onSave, disabled, table } ) {
 	const [ metaKey, setMetaKey ] = useState( keyLength.meta_key );
 	const [ metaValue, setMetaValue ] = useState( keyLength.meta_value );
 
@@ -136,6 +152,9 @@ function SettingsCard( { keyLength, onSave, disabled } ) {
 		setMetaKey( keyLength.meta_key );
 		setMetaValue( keyLength.meta_value );
 	}, [ keyLength ] );
+
+	const keyId = `mpmf-${ table }-meta-key-length`;
+	const valueId = `mpmf-${ table }-meta-value-length`;
 
 	return (
 		<Card>
@@ -151,14 +170,11 @@ function SettingsCard( { keyLength, onSave, disabled } ) {
 				</p>
 				<Flex align="end" gap={ 4 }>
 					<FlexItem>
-						<label
-							className="mpmf-label"
-							htmlFor="mpmf-meta-key-length"
-						>
+						<label className="mpmf-label" htmlFor={ keyId }>
 							{ __( 'Meta Key Length', 'mpmf' ) }
 						</label>
 						<input
-							id="mpmf-meta-key-length"
+							id={ keyId }
 							type="number"
 							className="mpmf-number-input"
 							min={ 32 }
@@ -171,14 +187,11 @@ function SettingsCard( { keyLength, onSave, disabled } ) {
 						/>
 					</FlexItem>
 					<FlexItem>
-						<label
-							className="mpmf-label"
-							htmlFor="mpmf-meta-value-length"
-						>
+						<label className="mpmf-label" htmlFor={ valueId }>
 							{ __( 'Meta Value Length', 'mpmf' ) }
 						</label>
 						<input
-							id="mpmf-meta-value-length"
+							id={ valueId }
 							type="number"
 							className="mpmf-number-input"
 							min={ 64 }
@@ -205,9 +218,12 @@ function SettingsCard( { keyLength, onSave, disabled } ) {
 }
 
 /**
- * Main application component.
+ * Table-specific view. Each tab renders this with a different table.
+ *
+ * @param {Object} props
+ * @param {string} props.table Table identifier (postmeta/usermeta/termmeta).
  */
-function App() {
+function TableView( { table } ) {
 	const [ loading, setLoading ] = useState( true );
 	const [ actionInProgress, setActionInProgress ] = useState( false );
 	const [ notice, setNotice ] = useState( null );
@@ -219,9 +235,12 @@ function App() {
 		key_length: { meta_key: 255, meta_value: 64 },
 	} );
 
+	const path = `${ API_BASE }/${ table }`;
+	const optionName = `mpmf-${ table }-key-length`;
+
 	const fetchStatus = () => {
 		setLoading( true );
-		apiFetch( { path: API_PATH } )
+		apiFetch( { path } )
 			.then( ( res ) => {
 				setData( res );
 				setLoading( false );
@@ -232,12 +251,13 @@ function App() {
 			} );
 	};
 
-	useEffect( fetchStatus, [] );
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	useEffect( fetchStatus, [ table ] );
 
 	const addIndex = ( update = false ) => {
 		setActionInProgress( true );
 		setNotice( null );
-		apiFetch( { path: API_PATH, method: 'POST', data: { update } } )
+		apiFetch( { path, method: 'POST', data: { update } } )
 			.then( ( res ) => {
 				setNotice( { type: 'success', message: res.message } );
 				fetchStatus();
@@ -259,7 +279,7 @@ function App() {
 		}
 		setActionInProgress( true );
 		setNotice( null );
-		apiFetch( { path: API_PATH, method: 'DELETE' } )
+		apiFetch( { path, method: 'DELETE' } )
 			.then( ( res ) => {
 				setNotice( { type: 'success', message: res.message } );
 				fetchStatus();
@@ -276,7 +296,7 @@ function App() {
 		apiFetch( {
 			path: '/wp/v2/settings',
 			method: 'POST',
-			data: { 'mpmf-postmeta-key-length': [ metaKey, metaValue ] },
+			data: { [ optionName ]: [ metaKey, metaValue ] },
 		} )
 			.then( () => {
 				setNotice( {
@@ -325,6 +345,7 @@ function App() {
 				keyLength={ data.key_length }
 				onSave={ saveSettings }
 				disabled={ isDisabled }
+				table={ table }
 			/>
 
 			<Flex className="mpmf-actions" gap={ 3 }>
@@ -374,6 +395,17 @@ function App() {
 				</FlexItem>
 			</Flex>
 		</div>
+	);
+}
+
+/**
+ * Main application component.
+ */
+function App() {
+	return (
+		<TabPanel className="mpmf-tabs" tabs={ TABLES }>
+			{ ( tab ) => <TableView table={ tab.name } /> }
+		</TabPanel>
 	);
 }
 


### PR DESCRIPTION
## Summary

Issue #20 対応。`wp_postmeta` に加えて `wp_usermeta` と `wp_termmeta` にも同じインデックス戦略を適用可能にする。

## 変更内容

### アーキテクチャのリファクタ
- `AbstractIndexChecker` の抽象クラスに共通実装を引き上げ:
  - `key_length()`: 全テーブル共通のオプション読み込み + サニタイズ (32-255 / 64-)
  - `add_index_query()`: 全3テーブルが同じ `(meta_key, meta_value)` 複合インデックスなので共通化
  - 抽象メソッド `option_name()` を追加（各テーブルのWP option名）
- `PostMetaIndexChecker` は重複メソッド削除、`option_name()` 実装のみに

### 新規クラス
- `IndexChecker/UserMetaIndexChecker.php` — `wp_usermeta` 用 (explain query: `meta_key='first_name' AND meta_value LIKE 'A%'`)
- `IndexChecker/TermMetaIndexChecker.php` — `wp_termmeta` 用 (explain query: `meta_key='order' AND meta_value LIKE '1%'`)

### REST API
- ルートを `/mpmf/v1/index` → `/mpmf/v1/index/{table}` にパラメータ化
- `GET /mpmf/v1/index` — 全3テーブルのステータスを一括取得 (ダッシュボード用)
- `GET/POST/DELETE /mpmf/v1/index/{table}` — 各テーブル操作 (`{table}` は正規表現で制限)
- 内部レジストリ `IndexApi::TABLES` でテーブル名 → Checker クラスマップ

### CLI
- `Command::map_dbname()` に2テーブル追加
- `wp index add usermeta`, `wp index clear termmeta` など全コマンドが動作

### 管理画面UI
- `@wordpress/components` の `TabPanel` で3タブ化: Post Meta / User Meta / Term Meta
- 既存のカード構成 (Status / Explain / Settings / Actions) を `TableView` として切り出し、各タブで独立インスタンス
- タブ切替時に該当テーブルのデータを fetch

### 設定
- `register_setting` を3つに (`mpmf-postmeta-key-length`, `mpmf-usermeta-key-length`, `mpmf-termmeta-key-length`)
- 既存 postmeta オプション名は維持 (後方互換)

## 動作確認

- [x] PHP 全ファイル文法 OK (`php -l`)
- [x] PHPCS 全10ファイル pass
- [x] JS lint pass
- [x] ビルド成功 (`npm run build:js` / `build:css` / `dump`)
- [x] CLI: `wp index display postmeta/usermeta/termmeta` 全て動作
- [x] REST API: `GET /index` で3テーブル返却、`POST /index/usermeta` で追加成功
- [x] 管理画面: 3タブ切替 OK、各タブの Status / EXPLAIN / Settings / Actions が独立動作
- [x] CLI ↔ REST API 整合性確認 (REST で usermeta 追加 → `wp index is-valid usermeta` で Success)
- [x] コンソールエラーゼロ

## Test plan

- [ ] CI `WordPress Plugin Test` が全グリーン
- [ ] 別環境で main から pull → `npm ci && npm run build:js build:css dump` → `npm start` → ツール > Meta Index で3タブ全てで add/remove テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)